### PR TITLE
rename project to attendify-front

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "attendify-front",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
This pull request includes a small but important change to the `package.json` file. The change updates the project name to reflect the new project identity.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Changed the project name from "vite-react-typescript-starter" to "attendify-front".